### PR TITLE
Remove unnecessary jgit pgm dependency, add annotations removed in Ja…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>1.3.5</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Core Library -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>org-netbeans-api-annotations-common</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
+        <!-- Annotations removed from Java 11+ -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
+        </dependency>
         <!-- Core Library -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -69,12 +75,6 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-awt</artifactId>
             <version>${netbeans.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit.pgm</artifactId>
-            <version>5.12.0.202106070339-r</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>


### PR DESCRIPTION
The jgit pgm dependency brings a whole lot of other dependencies (jetty, ssh, ...), making the resulting npm package huge. It seems it's is not necessary, I don't see any reference to its packages in the source code. Removing it shrinks the npm from 16MB to less than 3MB.

To compile on Java 11+, I added `jakarta.annotation-api`, which provides the `javax.annotation package`, which was removed from Java 11. This is just required for compilation, not needed at runtime. It's only for the `javax.annotation.Generated` in the `Bundle` class.